### PR TITLE
Scope function permission to WebSocket route key

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -79,6 +79,7 @@ Resources:
       Action: lambda:InvokeFunction
       FunctionName: !Ref MyLambdaRouteHandlerFunction
       Principal: apigateway.amazonaws.com
+      SourceArn: !Sub arn:${AWS::Partition}:execute-api:${AWS::Region}:${AWS::AccountId}:${MyWebSocketApi}/*/test
 
 Outputs:
     MyWebSocketApi:


### PR DESCRIPTION
Lambda permissions can be scoped to specific route keys. The AWS management console and Stackery both add this additional scoping. This change brings the example template in-line with these tools.