### PR TITLE
Fix response?

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,4 +1,6 @@
 module.exports.handler = async (event) => {
     console.log(JSON.stringify(event, 2));
-    return "Echoing your message: " + event.echo;
+    return {
+        body: "Echoing your message: " + event.echo
+    };
 };


### PR DESCRIPTION
I had to return the response as a string value of the `body` property of a returned object. When I tried to return just a string, like you had, I got responses like:

```JSON
{"message": "Internal server error", "connectionId":"bezT_clAoAMCLhg=", "requestId":"be0eDHpzoAMFyOg="}
```